### PR TITLE
Handle multi-valued CSS Shorthand styles

### DIFF
--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -94,6 +94,10 @@ function isEmpty(string) {
    return !/[^\s]/.test(string);
 }
 
+function containsSpaces(value) {
+  return /\s/.test(value);
+}
+
 /**
  * Determines if the specified string consists entirely of numeric characters.
  */
@@ -468,7 +472,7 @@ StyleParser.prototype = {
     if (isNumeric(value)) {
       // If numeric, no quotes
       return value;
-    } else if (endsWith(value, 'px')) {
+    } else if (endsWith(value, 'px') && !containsSpaces(value)) {
       // "500px" -> 500
       return trimEnd(value, 'px');
     } else {

--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -94,8 +94,15 @@ function isEmpty(string) {
    return !/[^\s]/.test(string);
 }
 
-function containsSpaces(value) {
-  return /\s/.test(value);
+/**
+ * Determines if the CSS value can be converted from a
+ * 'px' suffixed string to a numeric value
+ *
+ * @param {string} value CSS property value
+ * @return {boolean}
+ */
+function isConvertiblePixelValue(value) {
+  return /^\d+px$/.test(value);
 }
 
 /**
@@ -472,11 +479,11 @@ StyleParser.prototype = {
     if (isNumeric(value)) {
       // If numeric, no quotes
       return value;
-    } else if (endsWith(value, 'px') && !containsSpaces(value)) {
+    } else if (isConvertiblePixelValue(value)) {
       // "500px" -> 500
       return trimEnd(value, 'px');
     } else {
-      // Proably a string, wrap it in quotes
+      // Probably a string, wrap it in quotes
       return '\'' + value.replace(/'/g, '"') + '\'';
     }
   }

--- a/test/htmltojsx-test.js
+++ b/test/htmltojsx-test.js
@@ -88,6 +88,12 @@ describe('htmltojsx', function() {
         .toBe('<div style={{color: \'red\'}}>Test</div>');
     });
 
+    it('should convert CSS shorthand "style" values', function() {
+      var converter = new HTMLtoJSX({ createClass: false });
+      expect(converter.convert('<div style="padding: 10px 15px 20px 25px;">Test</div>').trim())
+        .toBe('<div style={{padding: \'10px 15px 20px 25px\'}}>Test</div>');
+    });
+
     it('should convert numeric "style" attributes', function() {
       var converter = new HTMLtoJSX({ createClass: false });
       expect(converter.convert('<div style="width: 100px">Test</div>').trim())


### PR DESCRIPTION
When dealing with inline styles, treat shorthand formatted value lists
as plain strings instead of parsing them for numeric and 'px' suffixes

**Background info:**
I was running into `Error: Parse Error: Line 3: Unexpected token ILLEGAL`
errors when dealing with inline styles in CSS shorthand format that end in
'px'. The converter attempted to strip the 'px' and convert the value to 
numeric, which won't work with the shorthand value list.