### PR TITLE
Maintain value-less attributes handled by JSX

### DIFF
--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -392,12 +392,13 @@ HTMLtoJSX.prototype = {
         return this._getStyleAttribute(attribute.value);
       default:
         var name = ATTRIBUTE_MAPPING[attribute.name] || attribute.name;
-        var result = name + '=';
+        var result = name;
+
         // Numeric values should be output as {123} not "123"
         if (isNumeric(attribute.value)) {
-          result += '{' + attribute.value + '}';
-        } else {
-          result += '"' + attribute.value.replace('"', '&quot;') + '"';
+          result += '={' + attribute.value + '}';
+        } else if (attribute.value.length > 0) {
+          result += '="' + attribute.value.replace('"', '&quot;') + '"';
         }
         return result;
     }

--- a/test/htmltojsx-test.js
+++ b/test/htmltojsx-test.js
@@ -117,5 +117,11 @@ describe('htmltojsx', function() {
       expect(converter.convert('<label for="potato">Test</label>').trim())
         .toBe('<label htmlFor="potato">Test</label>');
     });
+
+    it('should maintain value-less attributes', function() {
+      var converter = new HTMLtoJSX({ createClass: false });
+      expect(converter.convert('<input disabled>').trim())
+        .toBe('<input disabled />');
+    });
   });
 });


### PR DESCRIPTION
Attributes with optional values, like `disabled` for example, are
assigned an empty string as their value making them evaluate as falsy.
In HTML, if the value is omitted the attribute defaults to truthy and so
should be the case in the transform.

Currently:

```
> converter.convert("<input disabled>")
"<input disabled="" />
"
```

What should happen:

```
> converter.convert("<input disabled>")
"<input disabled />
"
```

JSX properly converts attributes with no values to `true`.

Fixes #12.