### PR TITLE
Convert “value” to “defaultValue” for editable fields

### DIFF
--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -22,9 +22,17 @@ var NODE_TYPE = {
   TEXT: 3,
   COMMENT: 8
 };
+
 var ATTRIBUTE_MAPPING = {
   'for': 'htmlFor',
   'class': 'className'
+};
+
+var ELEMENT_ATTRIBUTE_MAPPING = {
+  'input': {
+    'checked': 'defaultChecked',
+    'value': 'defaultValue'
+  }
 };
 
 /**
@@ -391,7 +399,12 @@ HTMLtoJSX.prototype = {
       case 'style':
         return this._getStyleAttribute(attribute.value);
       default:
-        var name = ATTRIBUTE_MAPPING[attribute.name] || attribute.name;
+        var tagName = node.tagName.toLowerCase();
+        var name =
+          (ELEMENT_ATTRIBUTE_MAPPING[tagName] &&
+            ELEMENT_ATTRIBUTE_MAPPING[tagName][attribute.name]) ||
+          ATTRIBUTE_MAPPING[attribute.name] ||
+          attribute.name;
         var result = name;
 
         // Numeric values should be output as {123} not "123"

--- a/test/htmltojsx-test.js
+++ b/test/htmltojsx-test.js
@@ -81,6 +81,24 @@ describe('htmltojsx', function() {
     ].join('\n'));
   });
 
+  it('should set <input> "value" to "defaultValue" to allow input editing', function() {
+    var converter = new HTMLtoJSX({ createClass: false });
+      expect(converter.convert('<input value="Darth Vader">').trim())
+        .toBe('<input defaultValue="Darth Vader" />');
+  });
+
+  it('should not set "value" to "defaultValue" for non-<input> elements', function() {
+    var converter = new HTMLtoJSX({ createClass: false });
+      expect(converter.convert('<select><option value="Hans"></select>').trim())
+        .toBe('<select><option value="Hans" /></select>');
+  });
+
+  it('should set <input> "checked" to "defaultChecked" to allow box checking', function() {
+    var converter = new HTMLtoJSX({ createClass: false });
+      expect(converter.convert('<input type="checkbox" checked>').trim())
+        .toBe('<input type="checkbox" defaultChecked />');
+  });
+
   describe('Attribute transformations', function() {
     it('should convert basic "style" attributes', function() {
       var converter = new HTMLtoJSX({ createClass: false });


### PR DESCRIPTION
If “value” is set on a React `<input>` element, the element is not
editable. To match the behavior of HTML where “value” is the starting or
default value, transform the attribute to “defaultValue” to make
`<input>` elements uncontrolled components[1] by default.

[1] https://facebook.github.io/react/docs/forms.html#uncontrolled-components

Fixes #14.