### PR TITLE
Incrementing version of JSDOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "src/cli.js",
   "dependencies": {
     "yargs": "~1.3.1",
-    "jsdom": "^4.4.0"
+    "jsdom": "~4.4.0"
   },
   "devDependencies": {
     "gulp": "~3.8.7",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "src/cli.js",
   "dependencies": {
     "yargs": "~1.3.1",
-    "jsdom": "~1.0.0-pre.6"
+    "jsdom": "^4.4.0"
   },
   "devDependencies": {
     "gulp": "~3.8.7",


### PR DESCRIPTION
This version works on Node.Js and does not use contextify. 