### PR TITLE
Downgrade jsdom to support Node 10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "src/cli.js",
   "dependencies": {
     "yargs": "~1.3.1",
-    "jsdom": "~4.4.0"
+    "jsdom": "~3.1.2"
   },
   "devDependencies": {
     "gulp": "~3.8.7",


### PR DESCRIPTION
jsdom version 4.x does not support Node 10. This PR aims to downgrade to jsdom 3.1.2 in order to support older version of node.

More info on this issue: tmpvar/jsdom#1071