### PR TITLE
Switch to jsdom no contextify

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "src/cli.js",
   "dependencies": {
     "yargs": "~1.3.1",
-    "jsdom": "~4.4.0"
+    "jsdom-no-contextify": "~3.1.0"
   },
   "devDependencies": {
     "gulp": "~3.8.7",


### PR DESCRIPTION
Hi guys,

  This PR aims to switch from `jsdom` to `jsdom-no-contextify`. jsdom version 4.4.x does not support Node 10, and jsdom 3.1.x has dependencies with contextify. Contextify has native build that requires Python.

   As a result, I believe it makes sense to move to jsdom-no-contextify. I tried running the build with react-magic and everything seems to be working fine.

Alan 