### PR TITLE
Edge case where <code> section has braces

### DIFF
--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -185,6 +185,7 @@ HTMLtoJSX.prototype = {
     this.output = '';
     this.level = 0;
     this._inPreTag = false;
+    this._inCodeTag = false;
   },
   /**
    * Main entry point to the converter. Given the specified HTML, returns a
@@ -377,6 +378,9 @@ HTMLtoJSX.prototype = {
     if (tagName === 'pre') {
       this._inPreTag = true;
     }
+    if (tagName === 'code') {
+      this._inCodeTag = true;
+    }
 
     this.output += '<' + tagName;
     if (attributes.length > 0) {
@@ -405,6 +409,9 @@ HTMLtoJSX.prototype = {
 
     if (tagName === 'pre') {
       this._inPreTag = false;
+    }
+    if (tagName === 'code') {
+      this._inCodeTag = false;
     }
   },
 
@@ -450,6 +457,13 @@ HTMLtoJSX.prototype = {
       if (text.indexOf('\n') > -1) {
         text = text.replace(/\n\s*/g, this._getIndentedNewline());
       }
+    }
+    if (this._inCodeTag && !this._inPreTag) {
+        text = text
+          .replace(/\'/g, "\"")
+          .replace(/(\{|\})/g, function(brace) {
+              return '{\'' + brace + '\'}';
+          });
     }
     this.output += text;
   },


### PR DESCRIPTION
This change adds `{'...'}` to any text outside of `pre` tags, but inside of `code` tags in case braces are used within the code tags.