### PR TITLE
Handle braces in text.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,10 @@ function getArgs() {
     )
     .describe('className', 'Create a React component (wraps JSX in React.createClass call)')
     .alias('className', 'c')
+    .boolean('e')
+    .describe('e', 'Decide whether to wrap in module.exports')
+    .boolean('g')
+    .describe('g', 'Decide whether to format for grouping with other jsx files(i.e. no wrapper)')
     .help('help')
     .example(
       '$0 -c AwesomeComponent awesome.htm',
@@ -38,7 +42,9 @@ function main() {
     }
     var converter = new HTMLtoJSX({
       createClass: !!argv.className,
-      outputClassName: argv.className
+      outputClassName: argv.className,
+      exports: argv.e && !argv.g,
+      group: argv.g && !argv.e
     });
     var output = converter.convert(input);
     console.log(output);

--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -446,6 +446,12 @@ HTMLtoJSX.prototype = {
           return '{' + JSON.stringify(whitespace) + '}';
         });
     } else {
+      // Handle any curly braces.
+      text = text
+        .replace(/\'/g, "\"")
+        .replace(/(\{|\})/g, function(brace) {
+            return '{\'' + brace + '\'}';
+        });
       // If there's a newline in the text, adjust the indent level
       if (text.indexOf('\n') > -1) {
         text = text.replace(/\n\s*/g, this._getIndentedNewline());

--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -434,7 +434,7 @@ HTMLtoJSX.prototype = {
       return;
     }
 
-    var text = escapeSpecialChars(node.textContent)
+    var text = escapeSpecialChars(node.textContent);
 
     if (this._inPreTag) {
       // If this text is contained within a <pre>, we need to ensure the JSX
@@ -448,7 +448,6 @@ HTMLtoJSX.prototype = {
     } else {
       // Handle any curly braces.
       text = text
-        .replace(/\'/g, "\"")
         .replace(/(\{|\})/g, function(brace) {
             return '{\'' + brace + '\'}';
         });

--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -198,14 +198,19 @@ HTMLtoJSX.prototype = {
     var containerEl = createElement('div');
     containerEl.innerHTML = '\n' + this._cleanInput(html) + '\n';
 
-    if (this.config.createClass) {
-      if (this.config.outputClassName) {
-        this.output = 'var ' + this.config.outputClassName + ' = React.createClass({\n';
-      } else {
-        this.output = 'React.createClass({\n';
+    if (this.config.exports) {
+       this.output = 'module.exports = ';
+    } else if (this.config.group){
+    } else {
+      if (this.config.createClass) {
+        if (this.config.outputClassName) {
+          this.output = 'var ' + this.config.outputClassName + ' = React.createClass({\n';
+        } else {
+          this.output = 'React.createClass({\n';
+        }
+        this.output += this.config.indent + 'render: function() {' + "\n";
+        this.output += this.config.indent + this.config.indent + 'return (\n';
       }
-      this.output += this.config.indent + 'render: function() {' + "\n";
-      this.output += this.config.indent + this.config.indent + 'return (\n';
     }
 
     if (this._onlyOneTopLevel(containerEl)) {
@@ -224,7 +229,7 @@ HTMLtoJSX.prototype = {
       this.output += this.config.indent + this.config.indent + ');\n';
       this.output += this.config.indent + '}\n';
       this.output += '});';
-    }
+    }else if (this.config.exports){ this.output += ';';}
     return this.output;
   },
 


### PR DESCRIPTION
This is a fix to handle braces written in the text.  It simply surrounds them with `{'..'}` which is the same method by which braces are handled inside of `pre` tags.  It was written in response to #42 .  @Daniel15, I assume this is the sort of thing that will work?