### PR TITLE
Removing jsx class-level indention when transforming HTML into JSX

### DIFF
--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -224,6 +224,8 @@ HTMLtoJSX.prototype = {
       this.output += this.config.indent + this.config.indent + ');\n';
       this.output += this.config.indent + '}\n';
       this.output += '});';
+    } else {
+      this.output = this._removeJSXClassIndention(this.output, this.config.indent);
     }
     return this.output;
   },
@@ -507,6 +509,19 @@ HTMLtoJSX.prototype = {
   _getStyleAttribute: function(styles) {
     var jsxStyles = new StyleParser(styles).toJSXString();
     return 'style={{' + jsxStyles + '}}';
+  },
+
+  /**
+   * Removes class-level indention in the JSX output. To be used when the JSX
+   * output is configured to not contain a class deifinition.
+   *
+   * @param {string} output JSX output with class-level indention
+   * @param {string} indent Configured indention
+   * @return {string} JSX output wihtout class-level indention
+   */
+  _removeJSXClassIndention: function(output, indent) {
+    var classIndention = new RegExp('\\n' + indent + indent + indent,  'g');
+    return output.replace(classIndention, '\n');
   }
 };
 


### PR DESCRIPTION
An example using the default example at http://magic.reactjs.net/htmltojsx.htm
 
If *Create class* is disabled the output is formatted like this:
```
<div>
        {/* Hello world */}
        <div className="awesome" style={{border: '1px solid red'}}>
          <label htmlFor="name">Enter your name: </label>
          <input type="text" id="name" />
        </div>
        <p>Enter your HTML here</p>
      </div>
```

With this pull request the output when *Create class* is disabled will instead be formatted like this :


```
<div>
  {/* Hello world */}
  <div className="awesome" style={{border: '1px solid red'}}>
    <label htmlFor="name">Enter your name: </label>
    <input type="text" id="name" />
  </div>
  <p>Enter your HTML here</p>
</div>
```