### PR TITLE
Additional options

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,10 @@ function getArgs() {
     )
     .describe('className', 'Create a React component (wraps JSX in React.createClass call)')
     .alias('className', 'c')
+    .boolean('e')
+    .describe('e', 'Decide whether to wrap in module.exports')
+    .boolean('g')
+    .describe('g', 'Decide whether to format for grouping with other jsx files(i.e. no wrapper)')
     .help('help')
     .example(
       '$0 -c AwesomeComponent awesome.htm',
@@ -38,7 +42,9 @@ function main() {
     }
     var converter = new HTMLtoJSX({
       createClass: !!argv.className,
-      outputClassName: argv.className
+      outputClassName: argv.className,
+      exports: argv.e && !argv.g,
+      group: argv.g && !argv.e
     });
     var output = converter.convert(input);
     console.log(output);

--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -198,14 +198,19 @@ HTMLtoJSX.prototype = {
     var containerEl = createElement('div');
     containerEl.innerHTML = '\n' + this._cleanInput(html) + '\n';
 
-    if (this.config.createClass) {
-      if (this.config.outputClassName) {
-        this.output = 'var ' + this.config.outputClassName + ' = React.createClass({\n';
-      } else {
-        this.output = 'React.createClass({\n';
+    if (this.config.exports) {
+       this.output = 'module.exports = ';
+    } else if (this.config.group){
+    } else {
+      if (this.config.createClass) {
+        if (this.config.outputClassName) {
+          this.output = 'var ' + this.config.outputClassName + ' = React.createClass({\n';
+        } else {
+          this.output = 'React.createClass({\n';
+        }
+        this.output += this.config.indent + 'render: function() {' + "\n";
+        this.output += this.config.indent + this.config.indent + 'return (\n';
       }
-      this.output += this.config.indent + 'render: function() {' + "\n";
-      this.output += this.config.indent + this.config.indent + 'return (\n';
     }
 
     if (this._onlyOneTopLevel(containerEl)) {
@@ -224,6 +229,8 @@ HTMLtoJSX.prototype = {
       this.output += this.config.indent + this.config.indent + ');\n';
       this.output += this.config.indent + '}\n';
       this.output += '});';
+    } else if (this.config.exports) {
+        this.output += ';';
     } else {
       this.output = this._removeJSXClassIndention(this.output, this.config.indent);
     }


### PR DESCRIPTION
This adds `e` and `g` options to wrap the jsx in `module.exports` and no wrapper respectively (the latter is for subsequent `g`rouping docs together into one large doc).  This replaces #56 