### PR TITLE
Add feature for SVG attributes conversion

### DIFF
--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -36,6 +36,7 @@ var ELEMENT_ATTRIBUTE_MAPPING = {
 };
 
 var HTMLDOMPropertyConfig = require('react-dom/lib/HTMLDOMPropertyConfig');
+var SVGDOMPropertyConfig = require('react-dom/lib/SVGDOMPropertyConfig');
 
 /**
  * Iterates over elements of object invokes iteratee for each element
@@ -54,16 +55,17 @@ function eachObj(obj, iteratee, context) {
 
 // Populate property map with ReactJS's attribute and property mappings
 // TODO handle/use .Properties value eg: MUST_USE_PROPERTY is not HTML attr
-for (var propname in HTMLDOMPropertyConfig.Properties) {
-  if (!HTMLDOMPropertyConfig.Properties.hasOwnProperty(propname)) {
-    continue;
-  }
+function mappingAttributesFromReactConfig(config) {
+  eachObj(config.Properties, function(propname) {
+    var mapFrom = config.DOMAttributeNames[propname] || propname.toLowerCase();
 
-  var mapFrom = HTMLDOMPropertyConfig.DOMAttributeNames[propname] || propname.toLowerCase();
-
-  if (!ATTRIBUTE_MAPPING[mapFrom])
-    ATTRIBUTE_MAPPING[mapFrom] = propname;
+    if (!ATTRIBUTE_MAPPING[mapFrom])
+      ATTRIBUTE_MAPPING[mapFrom] = propname;
+  });
 }
+
+mappingAttributesFromReactConfig(HTMLDOMPropertyConfig);
+mappingAttributesFromReactConfig(SVGDOMPropertyConfig);
 
 /**
  * Repeats a string a certain number of times.

--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -37,6 +37,21 @@ var ELEMENT_ATTRIBUTE_MAPPING = {
 
 var HTMLDOMPropertyConfig = require('react-dom/lib/HTMLDOMPropertyConfig');
 
+/**
+ * Iterates over elements of object invokes iteratee for each element
+ *
+ * @param {object}   obj        Collection object
+ * @param {function} iteratee   Callback function called in iterative processing
+ * @param {any}      context    This arg (aka Context)
+ */
+function eachObj(obj, iteratee, context) {
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      iteratee.call(context || obj, key, obj[key]);
+    }
+  }
+}
+
 // Populate property map with ReactJS's attribute and property mappings
 // TODO handle/use .Properties value eg: MUST_USE_PROPERTY is not HTML attr
 for (var propname in HTMLDOMPropertyConfig.Properties) {
@@ -562,12 +577,9 @@ StyleParser.prototype = {
    */
   toJSXString: function() {
     var output = [];
-    for (var key in this.styles) {
-      if (!this.styles.hasOwnProperty(key)) {
-        continue;
-      }
-      output.push(this.toJSXKey(key) + ': ' + this.toJSXValue(this.styles[key]));
-    }
+    eachObj(this.styles, function(key, value) {
+      output.push(this.toJSXKey(key) + ': ' + this.toJSXValue(value));
+    }, this);
     return output.join(', ');
   },
 

--- a/test/htmltojsx-test.js
+++ b/test/htmltojsx-test.js
@@ -142,19 +142,19 @@ describe('htmltojsx', function() {
       expect(converter.convert('<div style="-moz-hyphens: auto; -webkit-hyphens: auto">Test</div>').trim())
         .toBe('<div style={{MozHyphens: \'auto\', WebkitHyphens: \'auto\'}}>Test</div>');
     });
-    
+
     it('should convert uppercase vendor-prefix "style" attributes', function() {
       var converter = new HTMLtoJSX({ createClass: false });
       expect(converter.convert('<div style="-MOZ-HYPHENS: auto; -WEBKIT-HYPHENS: auto">Test</div>').trim())
         .toBe('<div style={{MozHyphens: \'auto\', WebkitHyphens: \'auto\'}}>Test</div>');
     });
-    
+
     it('should convert "style" attributes with vendor prefix-like strings in the middle and mixed case', function() {
       var converter = new HTMLtoJSX({ createClass: false });
       expect(converter.convert('<div style="myclass-MOZ-HYPHENS: auto; myclass-WEBKIT-HYPHENS: auto">Test</div>').trim())
         .toBe('<div style={{myclassMozHyphens: \'auto\', myclassWebkitHyphens: \'auto\'}}>Test</div>');
     });
-    
+
     it('should convert -ms- prefix "style" attributes', function() {
       var converter = new HTMLtoJSX({ createClass: false });
       expect(converter.convert('<div style="-ms-hyphens: auto">Test</div>').trim())
@@ -170,7 +170,7 @@ describe('htmltojsx', function() {
     it('should convert uppercase "style" attributes', function() {
       var converter = new HTMLtoJSX({ createClass: false });
       expect(converter.convert('<div style="TEXT-ALIGN: center">Test</div>').trim())
-        .toBe('<div style={{textAlign: \'center\'}}>Test</div>');  
+        .toBe('<div style={{textAlign: \'center\'}}>Test</div>');
     });
 
     it('should convert "class" attribute', function() {

--- a/test/htmltojsx-test.js
+++ b/test/htmltojsx-test.js
@@ -232,6 +232,12 @@ describe('htmltojsx', function() {
         expect(converter.convert('<input type="checkbox" checked>').trim())
           .toBe('<input type="checkbox" defaultChecked />');
     });
+
+    it('should convert SVG attributes', function() {
+      var converter = new HTMLtoJSX({ createClass: false });
+        expect(converter.convert('<svg height="100" width="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" fill-rule="evenodd"/></svg>').trim())
+          .toBe('<svg height={100} width={100}><circle cx={50} cy={50} r={40} stroke="black" strokeWidth={3} fill="red" fillRule="evenodd" /></svg>');
+    });
   });
 
   describe('special tags', function() {


### PR DESCRIPTION
Hi, Thank you for useful library :smiley:

I wanted to convert the attributes of SVG like #135.
However, when I actually convert it I got the following output.

```diff
- Actual: fill-rule, stroke-width
+ Expected: fillRule, strokeWidth
```

So we added `SVGDOMPropertyConfig` as an attribute mapping target as well as` HTMLDOMPropertyConfig`.

## Related issues

* [Convert hyphenated attributes into camelCase #135](https://github.com/reactjs/react-magic/issues/135)