### PR TITLE
Add CDN links to prop-types and create-react-class

### DIFF
--- a/site/htmltojsx.htm
+++ b/site/htmltojsx.htm
@@ -20,6 +20,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react-dom.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/3.21.0/codemirror.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/3.20.0/mode/javascript/javascript.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/create-react-class@15.6.0/create-react-class.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.6.0/prop-types.min.js"></script>
     <script src="https://facebook.github.io/react/js/live_editor.js"></script>
     <script src="htmltojsx.min.js"></script>
     <script src="htmltojsx-component.js"></script>


### PR DESCRIPTION
Fixes #141 - live_editor depends on `create-react-class` and `prop-types`. Can update the CDN urls if there's a better option. 