### PR TITLE
Fixed link to HTML-to-JSX online transform

### DIFF
--- a/README-htmltojsx.md
+++ b/README-htmltojsx.md
@@ -10,7 +10,7 @@ Installation
 npm install htmltojsx
 ```
 
-Alternatively, a web-based version is available at http://facebook.github.io/react/html-jsx.html
+Alternatively, a web-based version is available at http://magic.reactjs.net/htmltojsx.htm
 
 Usage
 =====


### PR DESCRIPTION
The [README](https://github.com/reactjs/react-magic/blob/master/README-htmltojsx.md) points to a [specific page on the old React website](https://github.com/facebook/react/blob/master/docs/html-jsx.html) that just redirects back to [a specific page on the react-magic website](http://magic.reactjs.net/htmltojsx.htm)- and with the launch of the new React website, the redirect page has been removed. So this PR updates the link to remove the needless redirect.

(The react-magic page is also broken but...that was the case beforehand too.)