### PR TITLE
Added onclick=> onClick to ATTRIBUTE_MAPPING

### DIFF
--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -26,6 +26,7 @@ var NODE_TYPE = {
 var ATTRIBUTE_MAPPING = {
   'for': 'htmlFor',
   'class': 'className'
+  'onclick': 'onClick'
 };
 
 var ELEMENT_ATTRIBUTE_MAPPING = {


### PR DESCRIPTION
Added onclick=> onClick to ATTRIBUTE_MAPPING. Because when transform **onclick** from HTML to Javascript React it will be **onClick** (refer to this link [https://reactjs.org/docs/handling-events.html](https://reactjs.org/docs/handling-events.html))
<img width="954" alt="screen shot 2017-11-22 at 10 13 31 am" src="https://user-images.githubusercontent.com/8603085/33108278-075c93dc-cf6e-11e7-918e-f09987ba01c6.png">
