### PR TITLE
Allow pipe from cli

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,31 +18,62 @@ function getArgs() {
       '$0 -c AwesomeComponent awesome.htm',
       'Creates React component "AwesomeComponent" based on awesome.htm'
     )
+    .example(
+      'cat file.htm | $0 -c AwesomeComponent',
+      'Creates React component "AwesomeComponent" based on data piped in'
+    )
     .strict();
 
   var files = args.argv._;
-  if (!files || files.length === 0) {
-    console.error('Please provide a file name');
-    args.showHelp();
-    process.exit(1);
+
+  // print error if called directly (not piped) and no files are specified
+  if (process.stdin.isTTY && (!files || files.length === 0)) {
+      console.error('Please provide a file name');
+      args.showHelp();
+      process.exit(1);
   }
   return args.argv;
 }
 
-function main() {
-  var argv = getArgs();
-  fs.readFile(argv._[0], 'utf-8', function(err, input) {
+function buildConverterCb(createClass, outputClassName) {
+  var converter = new HTMLtoJSX({
+    createClass: createClass,
+    outputClassName: outputClassName
+  });
+
+  return function(err, input) {
     if (err) {
       console.error(err.stack);
       process.exit(2);
     }
-    var converter = new HTMLtoJSX({
-      createClass: !!argv.className,
-      outputClassName: argv.className
-    });
+
     var output = converter.convert(input);
     console.log(output);
+    process.exit();
+  }
+}
+
+function readFromPipe(cb) {
+  var data = '';
+  process.stdin.resume()
+  process.stdin.setEncoding('utf8')
+  process.stdin.on('data', function(chunk) {
+    data += chunk;
   });
+  process.stdin.on('end', function() {
+    return cb(null, data);
+  });
+}
+
+
+function main() {
+  var argv = getArgs();
+  var convertInputCb = buildConverterCb(!!argv.className, argv.className);
+
+  if (process.stdin.isTTY) {
+    return fs.readFile(argv._[0], 'utf-8', convertInputCb);
+  }
+  return readFromPipe(convertInputCb);
 }
 
 main();


### PR DESCRIPTION
Added ability to take input from stdin so that html can be piped in.  

Executing 
`cat test/test.htm | ./src/cli.js  --className 'Tst'` 
results in same output as 
`htmltojsx -c 'Tst' ./test/test.htm`

```
var Tst = React.createClass({
  render: function() {
    return (
      <div>
        <meta httpEquiv="Content-Type" charSet="UTF-8" />
        <title>React-Magic Tests</title>
        <link rel="stylesheet" type="text/css" href="http://cdnjs.cloudflare.com/ajax/libs/jasmine/2.0.0/jasmine.css" />
        {/* Source files */}
        {/* Spec files */}
      </div>
    );
  }
});
```

------
Executing `echo '<div><p>fun in the sun?</p></div>' | ./src/cli.js  --className 'Tst'` results in

```
var Tst = React.createClass({
  render: function() {
    return (

      <div><p>fun in the sun?</p></div>
    );
  }
});
```
