### PR TITLE
Compact multilines attributes

### DIFF
--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -610,9 +610,14 @@ HTMLtoJSX.prototype = {
    * @return {string}
    */
   _getElementAttribute: function(node, attribute) {
+    var value = attribute.value;
+    // If there's some newlines in the value, compact it
+    if ( value.indexOf('\n') > -1 ) {
+      value = value.replace(/^\s+/mg, ' ').replace(/\n/g, '');
+    }
     switch (attribute.name) {
       case 'style':
-        return this._getStyleAttribute(attribute.value);
+        return this._getStyleAttribute(value);
       default:
         var tagName = jsxTagName(node.tagName);
         var name =
@@ -623,10 +628,10 @@ HTMLtoJSX.prototype = {
         var result = name;
 
         // Numeric values should be output as {123} not "123"
-        if (isNumeric(attribute.value)) {
-          result += '={' + attribute.value + '}';
-        } else if (attribute.value.length > 0) {
-          result += '="' + attribute.value.replace(/"/gm, '&quot;') + '"';
+        if (isNumeric(value)) {
+          result += '={' + value + '}';
+        } else if (value.length > 0) {
+          result += '="' + value.replace(/"/gm, '&quot;') + '"';
         }
         return result;
     }

--- a/test/htmltojsx-test.js
+++ b/test/htmltojsx-test.js
@@ -238,6 +238,17 @@ describe('htmltojsx', function() {
         expect(converter.convert('<svg height="100" width="100"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" fill-rule="evenodd"/></svg>').trim())
           .toBe('<svg height={100} width={100}><circle cx={50} cy={50} r={40} stroke="black" strokeWidth={3} fill="red" fillRule="evenodd" /></svg>');
     });
+
+    it('should compact multilignes attributes', function() {
+      var converter = new HTMLtoJSX({ createClass: false });
+        expect(converter.convert([
+        '<div class="cc1',
+        '            cc2',
+        '            cc3',
+        '            cc4">multilignes classes</div>'
+        ].join('\n')).trim())
+          .toBe('<div className="cc1 cc2 cc3 cc4">multilignes classes</div>');
+    });
   });
 
   describe('special tags', function() {


### PR DESCRIPTION
Compacting multi-lines attributes.

Keeping the indentation needs to rewrite all the attributes concatenation in __beginVisitElement_

`attributes.join(' ')`