### PR TITLE
Converting autofocus to autoFocus cameCased

### DIFF
--- a/src/htmltojsx.js
+++ b/src/htmltojsx.js
@@ -31,7 +31,8 @@ var ATTRIBUTE_MAPPING = {
 var ELEMENT_ATTRIBUTE_MAPPING = {
   'input': {
     'checked': 'defaultChecked',
-    'value': 'defaultValue'
+    'value': 'defaultValue',
+    'autofocus': 'autoFocus'
   }
 };
 


### PR DESCRIPTION
Converting `autofocus` input attribute to camel case version `autoFocus` and get rid of the following Warning:

> Invalid DOM property `autofocus`. Did you mean `autoFocus`?